### PR TITLE
Allows 2-way data binding to input value

### DIFF
--- a/src/components/Input/Input.svelte
+++ b/src/components/Input/Input.svelte
@@ -10,6 +10,7 @@
     export let type: SvelteInputProps['type'] = 'text'
     export let theme: SvelteInputProps['theme'] = null
     export let label: SvelteInputProps['label'] = ''
+    export let value: SvelteInputProps['value'] = ''
     export let subText: SvelteInputProps['subText'] = ''
     export let className: SvelteInputProps['className'] = ''
     export let labelClassName: SvelteInputProps['labelClassName'] = ''
@@ -38,7 +39,7 @@
     class={labelClasses}
 >
     {#if label}
-        <div class={styles.label}>{label}</div>
+        <div class={styles.label}>{@html label}</div>
     {/if}
     <ConditionalWrapper
         condition={$$slots.default}
@@ -47,8 +48,9 @@
     >
         <slot />
         <input
-            type={type}
+            {...{ type }}
             class={classes}
+            bind:value
             on:change={onChange}
             on:keyup={onKeyUp}
             on:input={onInput}


### PR DESCRIPTION


# Change summary

This PR has two small enhancements for the Input component:

1. Adds support to <Input> in svelte to do 2-way data binding. For example:
```
<script>
 let value=$state(0); // (svelte 5 syntax but should work
 </script>
 <Input type="number" bind:value />
```

2. Adds a small tweak to Input label to support html. Example:
```
    <Input
      type="number"
      id="miles-per-workday"
      bind:value={milesPerWeekday}
      label="Average miles driven <strong>per weekday</strong>"
    />
```
<img width="320" alt="Screenshot 2024-12-08 at 10 30 21 AM" src="https://github.com/user-attachments/assets/691cffdf-c1a8-4eb9-903c-f8f6dda8271a">

## 📝 Types of changes:

<!-- Put an `x` in all the boxes that apply -->

- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to change)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ⏫ Version upgrade
- [ ] 🧹 Refactor
- [ ] 📝 Changes to documentation

## 🧪 How to test:

<!-- Please provide a list of steps on how this change can be tested -->

- Visit `/input`
- Verify [TODO: should add examples in docs?]

## ✅ Checklist:

<!-- Please make sure the following has been checked prior to opening this PR -->

- [ ] Changes work across Astro/Svelte/React
- [ ] Changes has no negative A11y/Performance/SEO implications
- [ ] Changes have been tested on all breakpoints
- [ ] Unit and visual tests have been updated if needed
- [ ] Appropriate label has been assigned on PR

